### PR TITLE
[Hot Patch] `UserProfile` doesn't have `remove_contest()`

### DIFF
--- a/compete/models/participation.py
+++ b/compete/models/participation.py
@@ -85,8 +85,8 @@ class ContestParticipation(models.Model):
         if self.contest.is_rated and self.contest.ratings.exists():
             self.contest.rate()
         if self.is_disqualified:
-            if self.user.current_contest == self:
-                self.user.remove_contest()
+            # if self.user.current_contest == self:
+            #     self.user.remove_contest()
             self.contest.banned_users.add(self.user)
         else:
             self.contest.banned_users.remove(self.user)


### PR DESCRIPTION
Quick patch

<img width="238" alt="image" src="https://github.com/user-attachments/assets/bad8f0af-a603-4b34-a8b7-30e279fa3a8e" />

bkdnoj UserProfile doesn't use `current_contest` attribute